### PR TITLE
minify the mini

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,53 +1,40 @@
 export type CaseExecutor<In, R> = (value: In) => R;
-export type Case<T, R> = {value: T; execute: CaseExecutor<T, R>};
+export type Case<T, R> = { value: T; execute: CaseExecutor<T, R> };
 
 export interface Expression<T, R> {
-	case: <const In extends T, const Next>(value: In, execute: CaseExecutor<In, Next>) => Expression<T, R | Next>;
-	or: <const Next>(execute: CaseExecutor<T, Next>) => R | Next;
-	orThrow: () => R;
-	orNull: () => R | null;
+  case: <In extends T, Next>(value: In, execute: CaseExecutor<In, Next>) => Expression<T, R | Next>;
+  or: <Next>(execute: CaseExecutor<T, Next>) => R | Next;
+  orThrow: () => R;
+  orNull: () => R | null;
 }
 
 export function run<T, R>(rootValue: T, cases: Case<T, R>[], or: (value: T) => R): R {
-	for (const c of cases) {
-		if (rootValue === c.value) {
-			return c.execute(rootValue);
-		}
-	}
-
-	return or(rootValue);
+  for (const { value, execute } of cases) {
+    if (rootValue === value) {
+      return execute(rootValue);
+    }
+  }
+  return or(rootValue);
 }
 
 export function expression<T, R>(rootValue: T, cases: Case<T, R>[]): Expression<T, R> {
-	return {
-		case: <const In extends T, const Next>(value: In, execute: CaseExecutor<In, Next>) => {
-			const nextCases = [
-				...cases,
-				{
-					value,
-					execute,
-				},
-			] as Case<T, R>[];
-
-			return expression<T, R | Next>(rootValue, nextCases);
-		},
-
-		or: <const Next>(execute: CaseExecutor<T, Next>) => {
-			return run<T, R | Next>(rootValue, cases, value => execute(value));
-		},
-
-		orThrow: () => {
-			return run(rootValue, cases, () => {
-				throw new Error('Unhandled value passed to bwitch');
-			});
-		},
-
-		orNull: () => {
-			return run(rootValue, cases, () => null);
-		},
-	};
+  return {
+    case<In extends T, Next>(value: In, execute: CaseExecutor<In, Next>) {
+      const nextCases = [...cases, { value, execute }] as Case<T, R | Next>[];
+      return expression(rootValue, nextCases);
+    },
+    or<Next>(execute: CaseExecutor<T, Next>) {
+      return run(rootValue, cases, value => execute(value));
+    },
+    orThrow() {
+      throw new Error('Unhandled value passed to bwitch');
+    },
+    orNull() {
+      return null;
+    },
+  };
 }
 
-export function bwitch<const T, R = never>(value: T) {
-	return expression<T, R>(value, []);
+export function bwitch<T, R = never>(value: T) {
+  return expression(value, []);
 }


### PR DESCRIPTION
makes bwitch even smaller

- do we really need consts? i got rid of em
- used deconstructing inside run func
- type annotations should be inferred automatically inside `bwitch()` func

the only thing im not sure of is the `orThrow` part inside `expression`.
goes from 44 loc to 36 loc